### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# Triggered when a tag is pushed (e.g. `git push origin 1.5.0`).
+# The tag must match the `version` field in manifest.json or the job
+# fails fast — this catches the common "forgot to bump" mistake.
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Verify tag matches manifest.json version
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          manifest_version=$(node -p "require('./manifest.json').version")
+          if [ "$tag" != "$manifest_version" ]; then
+            echo "::error::Tag '$tag' does not match manifest.json version '$manifest_version'"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release create "$tag" \
+            --title "$tag" \
+            --generate-notes \
+            main.js manifest.json styles.css


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automates the release process for
this plugin. Releases happen on tag push: the action verifies the tag
matches `manifest.json`, runs the test suite, builds `main.js`, and
creates a GitHub release with the three required artifacts attached.

## Behaviour

The workflow runs on `push: tags: [*]`.

| Step | What it does |
| ---- | ------------ |
| Checkout | Standard `actions/checkout@v4` |
| Setup Node | Node 20 with npm cache |
| Install | `npm ci --legacy-peer-deps` (matches the local install command this repo already uses, due to the `@types/node` peer-dep range conflict introduced by Vitest) |
| Verify tag matches `manifest.json` | Fails fast with `::error::` annotation if the pushed tag isn't equal to the `version` in `manifest.json` — catches the common "forgot to bump" mistake |
| Run tests | `npm test` — refuses to release if the suite fails |
| Build | `npm run build` — produces `main.js` via the existing tsc + esbuild pipeline |
| Create release | `gh release create <tag> --title <tag> --generate-notes main.js manifest.json styles.css` |

`--generate-notes` builds the release description from PRs / commits
since the previous tag, so no manual notes are required (you can
still edit them on GitHub afterwards).

## New release flow once this lands

```
git checkout master && git pull
npm version <new-version>     # uses the existing version-bump.mjs to update manifest.json + versions.json, then commits + tags
git push --follow-tags        # pushes the commit and the new tag
# → workflow runs → release appears with assets attached
```

Three lines per release.

## Permissions / secrets

- `permissions: contents: write` on the job (required to create a
  release).
- Uses the built-in `GITHUB_TOKEN`. No additional secret to
  configure.

## Test plan

- [ ] Review the workflow file.
- [ ] Once merged, this can be exercised by tagging the next release
      (e.g. a future `1.5.1` patch). It does not run on this PR
      because the trigger is `push: tags`, not `pull_request`.
- [ ] Optional: tag this PR's commit on a fork to dry-run before
      cutting a real release.

## Notes

- Scope is limited to the release workflow only. A separate CI
  workflow that runs `npm test` on every PR would be a small
  follow-up if you want test gating on incoming PRs going forward —
  let me know.
- Action versions are pinned to major tags (`@v4`) for readability.
  Pinning to commit SHAs is more secure but adds maintenance; happy
  to switch if you'd prefer.

https://claude.ai/code/session_01VoorXoerBv9jMmtbCD2VjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoorXoerBv9jMmtbCD2VjY)_